### PR TITLE
fix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -230,6 +230,7 @@ if(NOT ARB_USE_BUNDLED_JSON)
 endif()
 
 cmake_dependent_option(ARB_USE_BUNDLED_RANDOM123 "Use bundled Random123 lib." ON "ARB_USE_BUNDLED_LIBS" OFF)
+add_library(ext-random123 INTERFACE)
 if(NOT ARB_USE_BUNDLED_RANDOM123)
     find_package(Random123 REQUIRED)
     target_include_directories(ext-random123 INTERFACE ${RANDOM123_INCLUDE_DIR})

--- a/arbor/include/arbor/simulation.hpp
+++ b/arbor/include/arbor/simulation.hpp
@@ -163,7 +163,7 @@ private:
 // An epoch callback function that prints out a text progress bar.
 ARB_ARBOR_API epoch_function epoch_progress_bar();
 
-void serialize(arb::serializer&, const std::string&, const arb::simulation&);
-void deserialize(arb::serializer&, const std::string&, arb::simulation&);
+ARB_ARBOR_API void serialize(arb::serializer&, const std::string&, const arb::simulation&);
+ARB_ARBOR_API void deserialize(arb::serializer&, const std::string&, arb::simulation&);
 
 } // namespace arb

--- a/arbor/simulation.cpp
+++ b/arbor/simulation.cpp
@@ -680,11 +680,11 @@ ARB_ARBOR_API epoch_function epoch_progress_bar() {
     return impl{};
 }
 
-void serialize(serializer& s, const std::string& k, const simulation& v) {
+ARB_ARBOR_API void serialize(serializer& s, const std::string& k, const simulation& v) {
     serialize(s, k, v.impl_);
 }
 
-void deserialize(serializer& s, const std::string& k, simulation& v) {
+ARB_ARBOR_API void deserialize(serializer& s, const std::string& k, simulation& v) {
     deserialize(s, k, v.impl_);
 }
 

--- a/ext/CMakeLists.txt
+++ b/ext/CMakeLists.txt
@@ -9,7 +9,6 @@ endif()
 
 # Random123 (DE Shaw Research) counter-based random number generators (header-only)
 
-add_library(ext-random123 INTERFACE)
 if(ARB_USE_BUNDLED_RANDOM123)
     check_git_submodule(random123 random123)
     if(NOT random123_avail)


### PR DESCRIPTION
- `random123` interface library must be declared in top level `CMakeLists.txt` to enable non-bundled external library
- symbols for serialization must be exported for shared library build